### PR TITLE
Fix incorrect viper instance used when reporting config file

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -54,7 +54,7 @@ func initConfig() {
 
 	// If a config file is found, read it in.
 	if err := notificatorViper.ReadInConfig(); err == nil {
-		fmt.Fprintln(os.Stderr, "Using config file:", viper.ConfigFileUsed())
+		fmt.Fprintln(os.Stderr, "Using config file:", notificatorViper.ConfigFileUsed())
 	}
 }
 


### PR DESCRIPTION
## Summary
- use the `notificatorViper` instance when printing the config file path

## Testing
- `go test ./...`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a09aa492b8832abb488863d6c6bd85